### PR TITLE
[fix] spawn args fail with nested quotes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,8 @@ function foreman(source) {
     const excludes = ignored.map(ignore => `--exclude="${ ignore }"`);
     const child = spawn('rsync', 
       ['-av', '--progress', ...excludes, source,  target ], {
-        stdio: ['inherit', 'inherit', 'inherit']
+        stdio: ['inherit', 'inherit', 'inherit'],
+        shell: true
       });
 
     child.on('close', function (code) {


### PR DESCRIPTION
looks like spawn breaks when arguments have nested quotes. currently all the excludes have nested quotes. added `shell:true` fixes the issue.
https://github.com/nodejs/node/issues/5060