### PR TITLE
Fix spawn

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,23 +58,24 @@ function foreman(source) {
    */
   function execute() {
     const excludes = ignored.map(ignore => `--exclude="${ ignore }"`);
-    const child = spawn('rsync', 
-      ['-av', '--progress', ...excludes, source,  target ], {
-        stdio: ['inherit', 'inherit', 'inherit']
-      });
+    console.log('!!! would have synced:', JSON.stringify(['-av', '--progress', ...excludes, source,  target ]));
+    // const child = spawn('rsync', 
+    //   ['-av', '--progress', ...excludes, source,  target ], {
+    //     stdio: ['inherit', 'inherit', 'inherit']
+    //   });
 
-    child.on('close', function (code) {
-      if (code !== 0) {
-        process.stderr.write(`rsync exited with ${ code }`);
-        process.exit(code);
-      }
+    // child.on('close', function (code) {
+    //   if (code !== 0) {
+    //     process.stderr.write(`rsync exited with ${ code }`);
+    //     process.exit(code);
+    //   }
 
-      setup();
-    });
+    //   setup();
+    // });
 
-    child.on('error', function (error) {
-      throw error;
-    });
+    // child.on('error', function (error) {
+    //   throw error;
+    // });
   }
 
   //


### PR DESCRIPTION
Apparently my original usage of `spawn` wasn't right and you can't send `--exclude="foo"` as a single argument it needs to come in as `['--exclude', 'foo']` in the args array.

That said, what's there in master right now with the buffer size change work for the large project I had, so other than a smaller memory footprint and immediate streaming of the rsync output, there's not a whole lot of immediate need to go back to spawn.